### PR TITLE
Replace query_title argument

### DIFF
--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -325,8 +325,8 @@ def main():
     print("\nRanking all collected papers semantically using SciBERT...")
     # Use the initially filtered papers for ranking
     semantically_ranked_papers: List[Dict] = semantic_rank_papers(
-        query_title=loaded_query_title, 
-        papers=papers_after_initial_filters, 
+        query=loaded_query_title,
+        papers=papers_after_initial_filters,
         top_n=len(papers_after_initial_filters) # Rank all available papers
     )
     


### PR DESCRIPTION
## Summary
- fix the semantic_rank_papers call by renaming argument `query_title` to `query`

## Testing
- `pytest -q`
- `python -m py_compile run_pipeline.py filter_and_rank.py api_client_manager.py embeddings.py keyword_critic.py paper_collector.py`


------
https://chatgpt.com/codex/tasks/task_e_68429abfc9608329a4d7c69a7b7691d2